### PR TITLE
Add podspec

### DIFF
--- a/PKMultipartInputStream.podspec
+++ b/PKMultipartInputStream.podspec
@@ -1,0 +1,19 @@
+
+Pod::Spec.new do |s|
+
+  s.name         = "PKMultipartInputStream"
+  s.version      = "0.0.1"
+  s.summary      = "An NSInputStream subclass suitable for building multipart/form-data HTTP requests bodies in MacOSX/iOS applications."
+  s.homepage     = "http://github.com/pyke369/PKMultipartInputStream"
+  s.license      = { :type => "MIT", :file => "LICENSE" }
+  s.author       = { "Pierre-Yves Kerembellec" => "py.kerembellec@gmail.com" }
+  s.preserve_paths = "README.*"
+
+  s.platform     = :ios
+
+  s.source       = { :git => "https://github.com/pyke369/PKMultipartInputStream.git", :commit => "2768229ec1d29f4212e033b7f23db81bc612a734" }
+  s.source_files = "PKMultipartInputStream.{h,m}"
+  s.requires_arc = true
+  s.frameworks   = "MobileCoreServices"
+
+end


### PR DESCRIPTION
Also the library in its current state is not OS X-compatible as it imports `UIKit`, and more important, requires `MobileCoreServices`.
# 

I’ve recently added [PKMultipartInputStream](https://github.com/CocoaPods/Specs/tree/master/PKMultipartInputStream) to the [CocoaPods](https://github.com/CocoaPods/CocoaPods) package manager repo.

CocoaPods is a tool for managing dependencies for OSX and iOS Xcode projects and provides a central repository for iOS/OSX libraries. This makes adding libraries to a project and updating them extremely easy and it will help users to resolve dependencies of the libraries they use.

However, PKMultipartInputStream doesn't have any version tags. I’ve added the current HEAD as version 0.0.1, but a version tag will make dependency resolution much easier.

[Semantic version](http://semver.org) tags (instead of plain commit hashes/revisions) allow for [resolution of cross-dependencies](https://github.com/CocoaPods/Specs/wiki/Cross-dependencies-resolution-example).

In case you didn’t know this yet; you can tag the current HEAD as, for instance, version 1.0.0, like so:

```
$ git tag -a 1.0.0 -m "Tag release 1.0.0"
$ git push --tags
```
