### PR TITLE
added ability to add NSData as a "file" part

### DIFF
--- a/PKMultipartInputStream.h
+++ b/PKMultipartInputStream.h
@@ -5,10 +5,13 @@
 - (void)addPartWithName:(NSString *)name string:(NSString *)string;
 - (void)addPartWithName:(NSString *)name data:(NSData *)data;
 - (void)addPartWithName:(NSString *)name data:(NSData *)data contentType:(NSString *)type;
+- (void)addPartWithName:(NSString *)name filename:(NSString*)filename data:(NSData *)data contentType:(NSString *)type;
+
 - (void)addPartWithName:(NSString *)name path:(NSString *)path;
 - (void)addPartWithName:(NSString *)name filename:(NSString *)filename path:(NSString *)path;
 - (void)addPartWithName:(NSString *)name filename:(NSString *)filename stream:(NSInputStream *)stream streamLength:(NSUInteger)streamLength;
 
 @property (nonatomic, readonly) NSString *boundary;
 @property (nonatomic, readonly) NSUInteger length;
+
 @end

--- a/PKMultipartInputStream.m
+++ b/PKMultipartInputStream.m
@@ -59,6 +59,16 @@ static NSString * MIMETypeForExtension(NSString * extension) {
     [self updateLength];
     return self;
 }
+- (id)initWithName:(NSString *)name boundary:(NSString *)boundary data:(NSData *)data contentType:(NSString *)contentType filename:(NSString*)filename
+{
+    self               = [super init];
+    self.headers       = [[NSString stringWithFormat:kHeaderPathFormat, boundary, name, filename, contentType] dataUsingEncoding:NSUTF8StringEncoding];
+    self.headersLength = [self.headers length];
+    self.body          = [NSInputStream inputStreamWithData:data];
+    self.bodyLength    = [data length];
+    [self updateLength];
+    return self;
+}
 - (id)initWithName:(NSString *)name filename:(NSString *)filename boundary:(NSString *)boundary path:(NSString *)path
 {
     if (!filename)
@@ -159,6 +169,12 @@ static NSString * MIMETypeForExtension(NSString * extension) {
     [self.parts addObject:[[PKMultipartElement alloc] initWithName:name boundary:self.boundary data:data contentType:type]];
     [self updateLength];
 }
+- (void)addPartWithName:(NSString *)name filename:(NSString*)filename data:(NSData *)data contentType:(NSString *)type
+{
+    [self.parts addObject:[[PKMultipartElement alloc] initWithName:name boundary:self.boundary data:data contentType:type filename:filename]];
+    [self updateLength];
+}
+
 - (void)addPartWithName:(NSString *)name path:(NSString *)path
 {
     [self.parts addObject:[[PKMultipartElement alloc] initWithName:name filename:nil boundary:self.boundary path:path]];


### PR DESCRIPTION
Flask based web service would't recognise NSData as a file until it had a filename - added extra method to add a NSData and give the part a filename.
