### PR TITLE
[#10] Synthesize NSInputStream delegate property

### DIFF
--- a/PKMultipartInputStream.m
+++ b/PKMultipartInputStream.m
@@ -138,6 +138,7 @@ static NSString * MIMETypeForExtension(NSString * extension) {
 @end
 
 @implementation PKMultipartInputStream
+@synthesize delegate;
 - (void)updateLength
 {
     self.length = self.footer.length + [[self.parts valueForKeyPath:@"@sum.length"] unsignedIntegerValue];


### PR DESCRIPTION
to avoid exceptions when using PKMultipartInputStream as body stream for NSURLSessionUploadTask. This addresses issue #10 