### PR TITLE
Adding parts with arbitrary HTTP headers

### DIFF
--- a/PKMultipartInputStream.h
+++ b/PKMultipartInputStream.h
@@ -11,6 +11,8 @@
 - (void)addPartWithName:(NSString *)name path:(NSString *)path;
 - (void)addPartWithName:(NSString *)name filename:(NSString *)filename path:(NSString *)path;
 - (void)addPartWithName:(NSString *)name filename:(NSString *)filename stream:(NSInputStream *)stream streamLength:(NSUInteger)streamLength;
+- (void)addPartWithHeaders:(NSDictionary *)headers string:(NSString *)string;
+- (void)addPartWithHeaders:(NSDictionary *)headers path:(NSString *)path;
 
 @property (nonatomic, readonly) NSString *boundary;
 @property (nonatomic, readonly) NSUInteger length;

--- a/PKMultipartInputStream.h
+++ b/PKMultipartInputStream.h
@@ -1,6 +1,8 @@
 // PKMultipartInputStream.h
 // py.kerembellec@gmail.com
 
+#import <Foundation/Foundation.h>
+
 @interface PKMultipartInputStream : NSInputStream
 - (void)addPartWithName:(NSString *)name string:(NSString *)string;
 - (void)addPartWithName:(NSString *)name data:(NSData *)data;


### PR DESCRIPTION
This allows to add parts together with their headers, instead forcing template headers offered by PKMultipartInputStream.

I needed this for streamed SOAP MTOM request, which requires different part headers than those baked to PKMultipartInputStream.

I think it adds a lot of flexibility to the library.

