### PR TITLE
Add the ability to manually specify the content type for files

### DIFF
--- a/PKMultipartInputStream.h
+++ b/PKMultipartInputStream.h
@@ -10,6 +10,7 @@
 - (void)addPartWithName:(NSString *)name filename:(NSString*)filename data:(NSData *)data contentType:(NSString *)type;
 - (void)addPartWithName:(NSString *)name path:(NSString *)path;
 - (void)addPartWithName:(NSString *)name filename:(NSString *)filename path:(NSString *)path;
+- (void)addPartWithName:(NSString *)name filename:(NSString *)filename path:(NSString *)path contentType:(NSString *)type;
 - (void)addPartWithName:(NSString *)name filename:(NSString *)filename stream:(NSInputStream *)stream streamLength:(NSUInteger)streamLength;
 - (void)addPartWithHeaders:(NSDictionary *)headers string:(NSString *)string;
 - (void)addPartWithHeaders:(NSDictionary *)headers path:(NSString *)path;

--- a/PKMultipartInputStream.m
+++ b/PKMultipartInputStream.m
@@ -71,11 +71,15 @@ static NSString * MIMETypeForExtension(NSString * extension) {
 }
 - (id)initWithName:(NSString *)name filename:(NSString *)filename boundary:(NSString *)boundary path:(NSString *)path
 {
+    return [self initWithName:name filename:filename boundary:boundary path:path contentType:MIMETypeForExtension(path.pathExtension)];
+}
+- (id)initWithName:(NSString *)name filename:(NSString *)filename boundary:(NSString *)boundary path:(NSString *)path contentType:(NSString *)contentType
+{
     if (!filename)
     {
         filename = path.lastPathComponent;
     }
-    self.headers       = [[NSString stringWithFormat:kHeaderPathFormat, boundary, name, filename, MIMETypeForExtension(path.pathExtension)] dataUsingEncoding:NSUTF8StringEncoding];
+    self.headers       = [[NSString stringWithFormat:kHeaderPathFormat, boundary, name, filename, contentType] dataUsingEncoding:NSUTF8StringEncoding];
     self.headersLength = [self.headers length];
     self.body          = [NSInputStream inputStreamWithFileAtPath:path];
     self.bodyLength    = [[[[NSFileManager defaultManager] attributesOfItemAtPath:path error:NULL] objectForKey:NSFileSize] unsignedIntegerValue];
@@ -234,6 +238,11 @@ static NSString * MIMETypeForExtension(NSString * extension) {
 - (void)addPartWithName:(NSString *)name filename:(NSString *)filename path:(NSString *)path
 {
     [self.parts addObject:[[PKMultipartElement alloc] initWithName:name filename:filename boundary:self.boundary path:path]];
+    [self updateLength];
+}
+- (void)addPartWithName:(NSString *)name filename:(NSString *)filename path:(NSString *)path contentType:(NSString *)type
+{
+    [self.parts addObject:[[PKMultipartElement alloc] initWithName:name filename:filename boundary:self.boundary path:path contentType:type]];
     [self updateLength];
 }
 - (void)addPartWithName:(NSString *)name filename:(NSString *)filename stream:(NSInputStream *)stream streamLength:(NSUInteger)streamLength


### PR DESCRIPTION
I use a backend service with strict MIME type checking, and the MIMETypeForExtension method does not choose the best value for some of the files I work with. This change allows you to manually override the contentType when desired.